### PR TITLE
docs: update route for build badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ MIT. Made with 💖
 [npm-downloads-src]: https://img.shields.io/npm/dm/rc9?style=flat-square
 [npm-downloads-href]: https://npmjs.com/package/rc9
 
-[github-actions-src]: https://img.shields.io/github/workflow/status/unjs/rc9/ci/main?style=flat-square
+[github-actions-src]: https://img.shields.io/github/actions/workflow/status/unjs/rc9/ci.yml?branch=main&style=flat-square
 [github-actions-href]: https://github.com/unjs/rc9/actions?query=workflow%3Aci
 
 [codecov-src]: https://img.shields.io/codecov/c/gh/unjs/rc9/main?style=flat-square


### PR DESCRIPTION
This commit fix the link the the build badge.
There was breaking change to the shield.io api for gh actions badges: badges/shields#8671