### PR TITLE
fix: stringify strings to avoid being cast to numbers

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -90,10 +90,7 @@ export function readUser<T extends RC = RC>(options?: RCOptions | string): T {
 
 export function serialize<T extends RC = RC>(config: T): string {
   return Object.entries(flat.flatten<RC, RC>(config))
-    .map(
-      ([key, value]) =>
-        `${key}=${typeof value === "string" ? value : JSON.stringify(value)}`
-    )
+    .map(([key, value]) => `${key}=${JSON.stringify(value)}`)
     .join("\n");
 }
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -37,7 +37,7 @@ describe("rc", () => {
 
   test("Update user config", () => {
     updateUser({ "db.password": '"123"' });
-    expect(readUser().db.password).toBe("123");
+    expect(readUser().db.password).toBe(`"123"`);
   });
 
   test("Parse ignore invalid lines", () => {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This ensures we stringify strings to avoid them being cast back to numbers when they are read (e.g. `021324`)

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
