### PR TITLE
feat: create target directory when writing config

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,8 @@ writeUserConfig({ token: 123 }, ".zoorc"); // Will be saved in ~/.config/.zoorc
 const conf = readUserConfig(".zoorc"); // { token: 123 }
 ```
 
+The config directory is created if it doesn't exist.
+
 > [!NOTE]
 > `readUser`/`writeUser`/`updateUser` are deprecated. Use `readUserConfig`/`writeUserConfig`/`updateUserConfig` instead, which follow XDG conventions (`~/.config`).
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
-import { existsSync, readFileSync, writeFileSync } from "node:fs";
-import { resolve } from "node:path";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
 import { homedir } from "node:os";
 import destr from "destr";
 import { flatten, unflatten } from "flat";
@@ -132,7 +132,9 @@ export function serialize<T extends RC = RC>(config: T): string {
  */
 export function write<T extends RC = RC>(config: T, options?: RCOptions | string) {
   options = withDefaults(options);
-  writeFileSync(resolve(options.dir!, options.name!), serialize(config), {
+  const path = resolve(options.dir!, options.name!);
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, serialize(config), {
     encoding: "utf8",
   });
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,13 @@
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { homedir } from "node:os";
 import destr from "destr";
 import { flatten, unflatten } from "flat";
 import { defu } from "defu";
+
+// User configuration often contains credentials, keep it readable by its owner only.
+const USER_DIR_MODE = 0o700;
+const USER_FILE_MODE = 0o600;
 
 const RE_KEY_VAL = /^\s*([^\s=]+)\s*=\s*(.*)?\s*$/;
 const RE_LINES = /\n|\r|\r\n/;
@@ -131,12 +135,23 @@ export function serialize<T extends RC = RC>(config: T): string {
  * @param {RCOptions|string} [options] - Options for writing the configuration file, or the name of the configuration file. See {@link RCOptions}.
  */
 export function write<T extends RC = RC>(config: T, options?: RCOptions | string) {
-  options = withDefaults(options);
+  _write(config, withDefaults(options), false);
+}
+
+function _write<T extends RC = RC>(config: T, options: RCOptions, secure: boolean) {
   const path = resolve(options.dir!, options.name!);
-  mkdirSync(dirname(path), { recursive: true });
+  mkdirSync(dirname(path), {
+    recursive: true,
+    ...(secure && { mode: USER_DIR_MODE }),
+  });
   writeFileSync(path, serialize(config), {
     encoding: "utf8",
+    ...(secure && { mode: USER_FILE_MODE }),
   });
+  if (secure) {
+    // `mode` above only applies to files created by this call.
+    chmodSync(path, USER_FILE_MODE);
+  }
 }
 
 /**
@@ -148,7 +163,7 @@ export function write<T extends RC = RC>(config: T, options?: RCOptions | string
 export function writeUser<T extends RC = RC>(config: T, options?: RCOptions | string) {
   options = withDefaults(options);
   options.dir = process.env.XDG_CONFIG_HOME || homedir();
-  write(config, options);
+  _write(config, options, true);
 }
 
 /**
@@ -170,7 +185,7 @@ export function readUserConfig<T extends RC = RC>(options?: RCOptions | string):
 export function writeUserConfig<T extends RC = RC>(config: T, options?: RCOptions | string) {
   options = withDefaults(options);
   options.dir = process.env.XDG_CONFIG_HOME || resolve(homedir(), ".config");
-  write(config, options);
+  _write(config, options, true);
 }
 
 /**
@@ -182,7 +197,7 @@ export function writeUserConfig<T extends RC = RC>(config: T, options?: RCOption
 export function updateUserConfig<T extends RC = RC>(config: T, options?: RCOptions | string): T {
   options = withDefaults(options);
   options.dir = process.env.XDG_CONFIG_HOME || resolve(homedir(), ".config");
-  return update(config, options);
+  return _update(config, options, true);
 }
 
 /**
@@ -192,12 +207,15 @@ export function updateUserConfig<T extends RC = RC>(config: T, options?: RCOptio
  * @returns {RC} - The updated configuration object. See {@link RC}.
  */
 export function update<T extends RC = RC>(config: T, options?: RCOptions | string): T {
-  options = withDefaults(options);
+  return _update(config, withDefaults(options), false);
+}
+
+function _update<T extends RC = RC>(config: T, options: RCOptions, secure: boolean): T {
   if (!options.flat) {
     config = unflatten(config, { overwrite: true });
   }
   const newConfig = defu(config, read(options));
-  write(newConfig, options);
+  _write(newConfig, options, secure);
   return newConfig as T;
 }
 
@@ -211,5 +229,5 @@ export function update<T extends RC = RC>(config: T, options?: RCOptions | strin
 export function updateUser<T extends RC = RC>(config: T, options?: RCOptions | string): T {
   options = withDefaults(options);
   options.dir = process.env.XDG_CONFIG_HOME || homedir();
-  return update(config, options);
+  return _update(config, options, true);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,10 +5,6 @@ import destr from "destr";
 import { flatten, unflatten } from "flat";
 import { defu } from "defu";
 
-// User configuration often contains credentials, keep it readable by its owner only.
-const USER_DIR_MODE = 0o700;
-const USER_FILE_MODE = 0o600;
-
 const RE_KEY_VAL = /^\s*([^\s=]+)\s*=\s*(.*)?\s*$/;
 const RE_LINES = /\n|\r|\r\n/;
 
@@ -138,19 +134,20 @@ export function write<T extends RC = RC>(config: T, options?: RCOptions | string
   _write(config, withDefaults(options), false);
 }
 
+// User configuration often contains credentials, keep it readable by its owner only (secure).
 function _write<T extends RC = RC>(config: T, options: RCOptions, secure: boolean) {
   const path = resolve(options.dir!, options.name!);
   mkdirSync(dirname(path), {
     recursive: true,
-    ...(secure && { mode: USER_DIR_MODE }),
+    ...(secure && { mode: 0o700 }),
   });
   writeFileSync(path, serialize(config), {
     encoding: "utf8",
-    ...(secure && { mode: USER_FILE_MODE }),
+    ...(secure && { mode: 0o600 }),
   });
   if (secure) {
     // `mode` above only applies to files created by this call.
-    chmodSync(path, USER_FILE_MODE);
+    chmodSync(path, 0o600);
   }
 }
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, rmSync } from "node:fs";
+import { chmodSync, existsSync, rmSync, statSync } from "node:fs";
 import { resolve } from "node:path";
 import { describe, test, expect, afterAll } from "vitest";
 import {
@@ -9,6 +9,8 @@ import {
   readUserConfig,
   writeUserConfig,
   updateUserConfig,
+  writeUser,
+  updateUser,
 } from "../src/index.ts";
 
 afterAll(() => {
@@ -122,5 +124,59 @@ describe("rc", () => {
         foo: ["A", "B"],
       },
     });
+  });
+});
+
+describe.skipIf(process.platform === "win32")("posix permissions", () => {
+  const mode = (path: string) => statSync(path).mode & 0o777;
+
+  const withConfigHome = (dir: string, fn: () => void) => {
+    const previousConfigHome = process.env.XDG_CONFIG_HOME;
+    process.env.XDG_CONFIG_HOME = dir;
+    rmSync(dir, { recursive: true, force: true });
+    try {
+      fn();
+    } finally {
+      if (previousConfigHome === undefined) {
+        delete process.env.XDG_CONFIG_HOME;
+      } else {
+        process.env.XDG_CONFIG_HOME = previousConfigHome;
+      }
+    }
+  };
+
+  for (const [name, writeConfig] of [
+    ["writeUser", writeUser],
+    ["writeUserConfig", writeUserConfig],
+    ["updateUser", updateUser],
+    ["updateUserConfig", updateUserConfig],
+  ] as const) {
+    test(`${name} creates private dir and file`, () => {
+      const dir = resolve(__dirname, `.tmp/perms/${name}`);
+      withConfigHome(dir, () => {
+        writeConfig(config, ".conf");
+        expect(mode(dir)).toBe(0o700);
+        expect(mode(resolve(dir, ".conf"))).toBe(0o600);
+      });
+    });
+
+    test(`${name} tightens permissions of an existing file`, () => {
+      const dir = resolve(__dirname, `.tmp/perms-existing/${name}`);
+      withConfigHome(dir, () => {
+        write(config, { dir, name: ".conf" });
+        chmodSync(resolve(dir, ".conf"), 0o644);
+        writeConfig(config, ".conf");
+        expect(mode(resolve(dir, ".conf"))).toBe(0o600);
+      });
+    });
+  }
+
+  test("write keeps default permissions", () => {
+    const dir = resolve(__dirname, ".tmp/perms-generic");
+    rmSync(dir, { recursive: true, force: true });
+    write(config, { dir, name: ".conf" });
+    const umask = process.umask();
+    expect(mode(dir)).toBe(0o777 & ~umask);
+    expect(mode(resolve(dir, ".conf"))).toBe(0o666 & ~umask);
   });
 });

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,4 +1,6 @@
-import { describe, test, expect } from "vitest";
+import { existsSync, rmSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, test, expect, afterAll } from "vitest";
 import {
   write,
   read,
@@ -8,6 +10,10 @@ import {
   writeUserConfig,
   updateUserConfig,
 } from "../src/index.ts";
+
+afterAll(() => {
+  rmSync(resolve(__dirname, ".tmp"), { recursive: true, force: true });
+});
 
 process.env.XDG_CONFIG_HOME = __dirname;
 
@@ -77,6 +83,32 @@ describe("rc", () => {
     const object = { x: 1, "x.y": 2 };
     update(object, { flat: true, name: ".conf2" });
     expect(read({ flat: true, name: ".conf2" })).toMatchObject(object);
+  });
+
+  test("Write config creates missing directories", () => {
+    const dir = resolve(__dirname, ".tmp/nested/deeply");
+    rmSync(dir, { recursive: true, force: true });
+    expect(existsSync(dir)).toBe(false);
+    write(config, { dir, name: ".conf" });
+    expect(read({ dir, name: ".conf" })).toMatchObject(config);
+  });
+
+  test("Update user config creates missing directories", () => {
+    const previousConfigHome = process.env.XDG_CONFIG_HOME;
+    process.env.XDG_CONFIG_HOME = resolve(__dirname, ".tmp/xdg/nested");
+    try {
+      const dir = resolve(__dirname, ".tmp/xdg/nested");
+      rmSync(dir, { recursive: true, force: true });
+      expect(existsSync(dir)).toBe(false);
+      updateUserConfig(config, ".conf-nested");
+      expect(readUserConfig(".conf-nested")).toMatchObject(config);
+    } finally {
+      if (previousConfigHome === undefined) {
+        delete process.env.XDG_CONFIG_HOME;
+      } else {
+        process.env.XDG_CONFIG_HOME = previousConfigHome;
+      }
+    }
   });
 
   test("Parse indexless arrays", () => {


### PR DESCRIPTION
this creates the config directory if it doesn't yet exist (unlikely, I know... but all the same)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configuration files can now be saved in nested directories that are created automatically.
  * User configuration directories and files use owner-only permissions, including existing files updated with stricter permissions.
  * Standard configuration writes retain default permission behavior.

* **Documentation**
  * Updated usage documentation to explain automatic configuration directory creation.

* **Tests**
  * Added coverage for nested directory creation and configuration file permissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->