### PR TITLE
feat: export `userConfigDir`

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ import {
   serialize,
   write,
   writeUser,
+  userConfigDir,
   readUserConfig,
   writeUserConfig,
   updateUserConfig,
@@ -114,7 +115,7 @@ writeUserConfig({ token: 123 }, ".zoorc"); // Will be saved in ~/.config/.zoorc
 const conf = readUserConfig(".zoorc"); // { token: 123 }
 ```
 
-The config directory is created if it doesn't exist.
+The config directory is created if it doesn't exist. Use `userConfigDir()` if you need to know where a value was written.
 
 > [!NOTE]
 > `readUser`/`writeUser`/`updateUser` are deprecated. Use `readUserConfig`/`writeUserConfig`/`updateUserConfig` instead, which follow XDG conventions (`~/.config`).
@@ -146,6 +147,7 @@ function parse(contents: string, options?: RCOptions): RC;
 function parseFile(path: string, options?: RCOptions): RC;
 function read(options?: RCOptions | string): RC;
 function readUserConfig(options?: RCOptions | string): RC;
+function userConfigDir(): string;
 function serialize(config: RC): string;
 function write(config: RC, options?: RCOptions | string): void;
 function writeUserConfig(config: RC, options?: RCOptions | string): void;

--- a/README.md
+++ b/README.md
@@ -114,6 +114,8 @@ writeUserConfig({ token: 123 }, ".zoorc"); // Will be saved in ~/.config/.zoorc
 const conf = readUserConfig(".zoorc"); // { token: 123 }
 ```
 
+The config directory is created if it doesn't exist.
+
 > [!NOTE]
 > `readUser`/`writeUser`/`updateUser` are deprecated. Use `readUserConfig`/`writeUserConfig`/`updateUserConfig` instead, which follow XDG conventions (`~/.config`).
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
-import { existsSync, readFileSync, writeFileSync } from "node:fs";
-import { resolve } from "node:path";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
 import { homedir } from "node:os";
 import destr from "destr";
 import { flatten, unflatten } from "flat";
@@ -132,7 +132,9 @@ export function serialize<T extends RC = RC>(config: T): string {
  */
 export function write<T extends RC = RC>(config: T, options?: RCOptions | string) {
   options = withDefaults(options);
-  writeFileSync(resolve(options.dir!, options.name!), serialize(config), {
+  const path = resolve(options.dir!, options.name!);
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, serialize(config), {
     encoding: "utf8",
   });
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -152,13 +152,21 @@ export function writeUser<T extends RC = RC>(config: T, options?: RCOptions | st
 }
 
 /**
+ * Resolves the directory used by the `*UserConfig` helpers: `$XDG_CONFIG_HOME` or `$HOME/.config`.
+ * @returns {string} - The absolute path to the user configuration directory.
+ */
+export function userConfigDir(): string {
+  return process.env.XDG_CONFIG_HOME || resolve(homedir(), ".config");
+}
+
+/**
  * Reads a configuration file from `$XDG_CONFIG_HOME` or `$HOME/.config` and parses its contents.
  * @param {RCOptions|string} [options] - Options for reading the configuration file, or the name of the configuration file. See {@link RCOptions}.
  * @returns {RC} - The parsed configuration object.
  */
 export function readUserConfig<T extends RC = RC>(options?: RCOptions | string): T {
   options = withDefaults(options);
-  options.dir = process.env.XDG_CONFIG_HOME || resolve(homedir(), ".config");
+  options.dir = userConfigDir();
   return read(options);
 }
 
@@ -169,7 +177,7 @@ export function readUserConfig<T extends RC = RC>(options?: RCOptions | string):
  */
 export function writeUserConfig<T extends RC = RC>(config: T, options?: RCOptions | string) {
   options = withDefaults(options);
-  options.dir = process.env.XDG_CONFIG_HOME || resolve(homedir(), ".config");
+  options.dir = userConfigDir();
   write(config, options);
 }
 
@@ -181,7 +189,7 @@ export function writeUserConfig<T extends RC = RC>(config: T, options?: RCOption
  */
 export function updateUserConfig<T extends RC = RC>(config: T, options?: RCOptions | string): T {
   options = withDefaults(options);
-  options.dir = process.env.XDG_CONFIG_HOME || resolve(homedir(), ".config");
+  options.dir = userConfigDir();
   return update(config, options);
 }
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -9,6 +9,7 @@ import {
   readUserConfig,
   writeUserConfig,
   updateUserConfig,
+  userConfigDir,
 } from "../src/index.ts";
 
 afterAll(() => {
@@ -97,9 +98,8 @@ describe("rc", () => {
     const previousConfigHome = process.env.XDG_CONFIG_HOME;
     process.env.XDG_CONFIG_HOME = resolve(__dirname, ".tmp/xdg/nested");
     try {
-      const dir = resolve(__dirname, ".tmp/xdg/nested");
-      rmSync(dir, { recursive: true, force: true });
-      expect(existsSync(dir)).toBe(false);
+      rmSync(userConfigDir(), { recursive: true, force: true });
+      expect(existsSync(userConfigDir())).toBe(false);
       updateUserConfig(config, ".conf-nested");
       expect(readUserConfig(".conf-nested")).toMatchObject(config);
     } finally {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,4 +1,6 @@
-import { describe, test, expect } from "vitest";
+import { existsSync, rmSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, test, expect, afterAll } from "vitest";
 import {
   write,
   read,
@@ -8,6 +10,10 @@ import {
   writeUserConfig,
   updateUserConfig,
 } from "../src/index.ts";
+
+afterAll(() => {
+  rmSync(resolve(__dirname, ".tmp"), { recursive: true, force: true });
+});
 
 process.env.XDG_CONFIG_HOME = __dirname;
 
@@ -77,6 +83,32 @@ describe("rc", () => {
     const object = { x: 1, "x.y": 2 };
     update(object, { flat: true, name: ".conf2" });
     expect(read({ flat: true, name: ".conf2" })).toMatchObject(object);
+  });
+
+  test("Write config creates missing directories", () => {
+    const dir = resolve(__dirname, ".tmp/nested/deeply");
+    rmSync(dir, { recursive: true, force: true });
+    expect(existsSync(dir)).toBe(false);
+    write(config, { dir, name: ".conf" });
+    expect(read({ dir, name: ".conf" })).toMatchObject(config);
+  });
+
+  test("Update user config creates missing directories", () => {
+    const previousConfigHome = process.env.XDG_CONFIG_HOME;
+    process.env.XDG_CONFIG_HOME = resolve(__dirname, ".tmp/xdg/nested");
+    try {
+      const dir = resolve(__dirname, ".tmp/xdg/nested");
+      rmSync(dir, { recursive: true, force: true });
+      expect(existsSync(dir)).toBe(false);
+      updateUserConfig(config, ".conf-nested");
+      expect(readUserConfig(".conf-nested")).toMatchObject(config);
+    } finally {
+      if (previousConfigHome === undefined) {
+        delete process.env.XDG_CONFIG_HOME;
+      } else {
+        process.env.XDG_CONFIG_HOME = previousConfigHome;
+      }
+    }
   });
 
   test("Parse indexless arrays", () => {


### PR DESCRIPTION
this adds a new `userConfigDir` getter to expose the same value used internally in `rc9`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a `userConfigDir()` helper that returns the user configuration directory based on standard environment settings.
  - User configuration read, write, and update operations now consistently use this directory.

- **Documentation**
  - Documented the new helper, including usage and its exported API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->