### PR TITLE
feat: ensure target directory exists when writing configuration

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
-import { existsSync, readFileSync, writeFileSync } from "node:fs";
-import { resolve } from "node:path";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
 import { homedir } from "node:os";
 import destr from "destr";
 import { flatten, unflatten } from "flat";
@@ -28,6 +28,13 @@ export interface RCOptions {
    * @optional
    */
   flat?: boolean;
+
+  /**
+   * Automatically create directory if it does not exist when writing.
+   * @default true
+   * @optional
+   */
+  createDir?: boolean;
 }
 
 /**
@@ -132,7 +139,11 @@ export function serialize<T extends RC = RC>(config: T): string {
  */
 export function write<T extends RC = RC>(config: T, options?: RCOptions | string) {
   options = withDefaults(options);
-  writeFileSync(resolve(options.dir!, options.name!), serialize(config), {
+  const filePath = resolve(options.dir!, options.name!);
+  if (options.createDir !== false) {
+    mkdirSync(dirname(filePath), { recursive: true });
+  }
+  writeFileSync(filePath, serialize(config), {
     encoding: "utf8",
   });
 }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,4 +1,5 @@
 import { describe, test, expect } from "vitest";
+import { resolve } from "node:path";
 import {
   write,
   read,
@@ -90,5 +91,11 @@ describe("rc", () => {
         foo: ["A", "B"],
       },
     });
+  });
+
+  test("Write config to non-existent directory", () => {
+    const nestedDir = resolve(process.cwd(), ".tmp/nested/dir");
+    write(config, { dir: nestedDir, name: ".conf" });
+    expect(read({ dir: nestedDir, name: ".conf" })).toMatchObject(config);
   });
 });


### PR DESCRIPTION
## Problem

Writing configuration to a non-existent directory (e.g. nested subdirectories or non-existent `$XDG_CONFIG_HOME` directories) fails with `ENOENT: no such file or directory`.

## Root Cause

`write` invoked `writeFileSync` directly without ensuring the target directory exists.

## Fix

- Added `createDir` option to `RCOptions` (default `true`).
- In `write`, call `mkdirSync(dirname(filePath), { recursive: true })` when `createDir !== false`.

## Testing

- Added unit test in `test/index.test.ts` verifying `write` to nested non-existent directory.
- Verified all 12 test cases and typecheck pass cleanly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Writing configuration files now automatically creates missing parent directories by default.
  - Added an option to disable automatic directory creation when needed.

- **Bug Fixes**
  - Configuration writes to nested, non-existent directories now complete successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->