### PR TITLE
fix(parse): replace a non-array value when a key ends with `[]`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -46,6 +46,10 @@ function withDefaults(options?: RCOptions | string): RCOptions {
   return { ...defaults, ...options };
 }
 
+function isUnsafeKey(key: string): boolean {
+  return key === "__proto__" || key === "constructor";
+}
+
 export function parse<T extends RC = RC>(contents: string, options: RCOptions = {}): T {
   const config: RC = {};
 
@@ -60,7 +64,7 @@ export function parse<T extends RC = RC>(contents: string, options: RCOptions = 
     // Key
     const key = match[1];
 
-    if (!key || key === "__proto__" || key === "constructor") {
+    if (!key || isUnsafeKey(key)) {
       continue;
     }
 
@@ -68,8 +72,16 @@ export function parse<T extends RC = RC>(contents: string, options: RCOptions = 
 
     if (key.endsWith("[]")) {
       const nkey = key.slice(0, Math.max(0, key.length - 2));
+
+      if (!nkey || isUnsafeKey(nkey)) {
+        continue;
+      }
+
+      const previous = config[nkey];
+      // A non-array value under the same key is replaced, not appended to:
+      // `concat` on a string silently joins and on a number or object throws.
       // eslint-disable-next-line unicorn/prefer-spread
-      config[nkey] = (config[nkey] || []).concat(value);
+      config[nkey] = Array.isArray(previous) ? previous.concat(value) : [value];
       continue;
     }
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -125,6 +125,21 @@ describe("rc", () => {
       },
     });
   });
+
+  test("Indexless array replaces a non-array value under the same key", () => {
+    // `concat` used to throw on a number and silently join a string.
+    expect(parse("a=1\na[]=2", { flat: true })).toMatchObject({ a: [2] });
+    expect(parse('a="x"\na[]=2', { flat: true })).toMatchObject({ a: [2] });
+    expect(parse('a={ "b": 1 }\na[]=2', { flat: true })).toMatchObject({ a: [2] });
+    expect(parse("a=1\na[]=2\na[]=3", { flat: true })).toMatchObject({ a: [2, 3] });
+  });
+
+  test("Indexless array keys cannot reach the prototype", () => {
+    const parsed = parse("__proto__[]=1\nconstructor[]=2\n[]=3", { flat: true });
+    expect(Object.keys(parsed)).toHaveLength(0);
+    expect(Array.isArray(Object.getPrototypeOf(parsed))).toBe(false);
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+  });
 });
 
 describe.skipIf(process.platform === "win32")("posix permissions", () => {


### PR DESCRIPTION
`parse` builds indexless arrays with `(config[nkey] || []).concat(value)`, which assumes whatever already sits under the key is an array. When the same key was also assigned a plain value, it is not:

```ts
parse("a=1\na[]=2");
// TypeError: (config[nkey] || []).concat is not a function
```

A number or an object throws outright. A string is worse, because it succeeds silently:

```ts
parse('a="x"\na[]=2'); // { a: "x2" }  — a string, not an array
```

A config file is user input, so a stray duplicate key crashes `read()`/`parse()` instead of producing a value.

### Changes

- Append only when the previous value really is an array; otherwise the `[]` entry starts a fresh one. That matches how a plain key overwrites an earlier assignment, so `a=1` + `a[]=2` is now `{ a: [2] }`.
- Apply the existing prototype guard to the stripped key too. The guard runs on the raw key, so `__proto__` is rejected but `__proto__[]` slipped through to `concat` on `Object.prototype` and threw. The same check also drops a bare `[]=1` (empty key), which previously created an `""` entry.

The guard is factored into a small `isUnsafeKey` helper so both call sites stay in sync.

### Validation

`pnpm test` (oxlint + oxfmt + `tsc --noEmit` + vitest with coverage) passes: 24 tests, 0 failures.

Both new tests fail on `main` and pass with the fix:

```
Tests  2 failed | 22 passed (24)   # src/index.ts reverted
Tests  24 passed (24)              # with the fix
```

No public API change; the existing `x.foo[]=A` / `x.foo[]=B` behaviour is unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved parsing safety by rejecting unsafe keys that could affect object prototypes.
  - Prevented array-style inputs from causing prototype pollution.
  - Corrected array accumulation so existing non-array values are replaced with a single-item array instead of being incorrectly combined.
  - Added coverage for unsafe keys and replacement behavior when parsing flat data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->